### PR TITLE
Fix fetching content based on the previous implementation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/contentful/contentful.swift",
         "state": {
           "branch": null,
-          "revision": "59402c444e0015c2e781e2212e2d815ad8c11745",
-          "version": "5.0.9"
+          "revision": "91f2306270a76fadc4c0c8237eff22966b608c08",
+          "version": "5.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/contentful/contentful.swift",
-            .upToNextMajor(from: "5.0.9")),
+            .upToNextMajor(from: "5.3.0")),
         .package(
             url: "https://github.com/kylef/Commander",
             .upToNextMajor(from: "0.9.1")),

--- a/Sources/ContentfulSyncSerializer/Client+UtilitiesSync.swift
+++ b/Sources/ContentfulSyncSerializer/Client+UtilitiesSync.swift
@@ -73,7 +73,7 @@ extension Client {
                     completion(.failure(error))
                 }
 
-            case .error(let error):
+            case .failure(let error):
                 completion(.failure(error))
             }
         }
@@ -108,7 +108,7 @@ extension Client {
                     completion: completion
                 )
 
-            case .error(let error):
+            case .failure(let error):
                 completion(.failure(error))
             }
         }

--- a/Sources/ContentfulSyncSerializer/Client+UtilitiesSync.swift
+++ b/Sources/ContentfulSyncSerializer/Client+UtilitiesSync.swift
@@ -1,0 +1,116 @@
+//
+//  ContentfulSyncSerializer
+//
+//  Created by Tomasz Szulc on 14/10/2020.
+//
+
+import Contentful
+import Foundation
+
+extension Client {
+
+    @discardableResult
+    func fetchContent(
+        for syncSpace: SyncSpace,
+        shouldDownloadAssets: Bool,
+        reportDownloadedSyncSpace: @escaping (SyncSpace, Data, URL) -> Void,
+        reportDownloadedAsset: @escaping (Asset, Data) -> Void,
+        then completion: @escaping (Swift.Result<Void, Error>) -> Void
+    ) -> URLSessionDataTask? {
+        let parameters: [String: String]
+        if syncSpace.hasMorePages {
+            parameters = syncSpace.parameters
+        } else {
+            parameters = SyncSpace.SyncableTypes.all.parameters + syncSpace.parameters
+        }
+
+        let url = self.url(endpoint: .sync, parameters: parameters)
+
+        return self.fetch(url: url) { [weak self] result in
+            guard let self = self else {
+                completion(.failure(SyncJSONDownloader.Error.failedToFetchSyncSpace))
+                return
+            }
+
+            switch result {
+            case .success(let data):
+                do {
+                    let updatedSyncSpace = try self.jsonDecoder.decode(SyncSpace.self, from: data)
+                    reportDownloadedSyncSpace(updatedSyncSpace, data, url)
+
+                    if shouldDownloadAssets {
+                        self.fetchAssets(
+                            assets: updatedSyncSpace.assets,
+                            reportDownloadedAsset: reportDownloadedAsset,
+                            completion: { result in
+                                if updatedSyncSpace.hasMorePages {
+                                    self.fetchContent(
+                                        for: updatedSyncSpace,
+                                        shouldDownloadAssets: shouldDownloadAssets,
+                                        reportDownloadedSyncSpace: reportDownloadedSyncSpace,
+                                        reportDownloadedAsset: reportDownloadedAsset,
+                                        then: completion
+                                    )
+                                } else {
+                                    completion(.success(()))
+                                }
+                            }
+                        )
+                    } else {
+                        if updatedSyncSpace.hasMorePages {
+                            self.fetchContent(
+                                for: updatedSyncSpace,
+                                shouldDownloadAssets: shouldDownloadAssets,
+                                reportDownloadedSyncSpace: reportDownloadedSyncSpace,
+                                reportDownloadedAsset: reportDownloadedAsset,
+                                then: completion
+                            )
+                        } else {
+                            completion(.success(()))
+                        }
+                    }
+                } catch let error {
+                    completion(.failure(error))
+                }
+
+            case .error(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func fetchAssets(
+        assets: [Asset],
+        reportDownloadedAsset: @escaping (Asset, Data) -> Void,
+        completion: @escaping (Swift.Result<Void, Error>) -> Void
+    ) {
+        guard let asset = assets.last else {
+            completion(.success(()))
+            return
+        }
+
+        var remainingAssets = assets
+        remainingAssets.removeLast()
+
+        self.fetchData(for: asset) { [weak self] result in
+            guard let self = self else {
+                completion(.failure(SyncJSONDownloader.Error.clientNotAvailable))
+                return
+            }
+
+            switch result {
+            case .success(let data):
+                reportDownloadedAsset(asset, data)
+
+                self.fetchAssets(
+                    assets: remainingAssets,
+                    reportDownloadedAsset: reportDownloadedAsset,
+                    completion: completion
+                )
+
+            case .error(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Sources/ContentfulSyncSerializer/SyncJSONDownloader.swift
+++ b/Sources/ContentfulSyncSerializer/SyncJSONDownloader.swift
@@ -2,13 +2,23 @@ import Contentful
 import Files
 import Foundation
 import PromiseKit
+
 public final class SyncJSONDownloader {
+
     private let spaceId: String
     private let accessToken: String
     private let outputDirectoryPath: String
     private let shouldDownloadMediaFiles: Bool
     private let environment: String
-    public init(spaceId: String, accessToken: String, outputDirectoryPath: String, environment: String = "master", shouldDownloadMediaFiles: Bool) {
+    private var entriesFileNameIndex: Int = 0
+
+    public init(
+        spaceId: String,
+        accessToken: String,
+        outputDirectoryPath: String,
+        environment: String = "master",
+        shouldDownloadMediaFiles: Bool
+    ) {
         self.spaceId = spaceId
         self.environment = environment
         self.accessToken = accessToken
@@ -17,18 +27,22 @@ public final class SyncJSONDownloader {
     }
 
     public func run(then completion: @escaping (Contentful.Result<Bool>) -> Void) {
-        let client = Client(spaceId: spaceId, environmentId: environment,
-                            accessToken: accessToken)
+        self.entriesFileNameIndex = 0
+
+        let client = Client(
+            spaceId: spaceId,
+            environmentId: environment,
+            accessToken: accessToken
+        )
+
         firstly {
-            sync(client: client)
+            self.sync(client: client)
+        }.then { _ in
+            self.fetchLocales(withClient: client).map({ SyncSpace() })
         }.then { syncSpace in
-            self.fetchLocales(withClient: client).map({ syncSpace })
-        }.then { syncSpace in
-            self.fetchSync(withClient: client, syncSpace: syncSpace).map({ syncSpace })
-        }.then { syncSpace in
-            self.fetchAssets(withClient: client, syncSpace: syncSpace)
+            self.fetchContent(withClient: client, syncSpace: syncSpace).map({ SyncSpace() })
         }.done { _ in
-            completion(Result.success(true))
+            completion(.success(true))
         }.catch { error in
             completion(.error(error))
         }
@@ -50,41 +64,6 @@ public final class SyncJSONDownloader {
         }
     }
 
-    private func fetchAssets(withClient client: Client, syncSpace space: SyncSpace) -> Promise<Void> {
-        return Promise { promise in
-            if shouldDownloadMediaFiles == false || space.assets.isEmpty {
-                promise.fulfill(())
-                return
-            }
-            let syncGroup = DispatchGroup()
-            var imageSaveErrorCount = 0
-            for asset in space.assets {
-                syncGroup.enter()
-                client.fetchData(for: asset) { [weak self] data in
-                    do {
-                        guard let fetched = data.value else {
-                            syncGroup.leave()
-                            return
-                        }
-                        try self?.saveData(fetched, for: asset.file?.fileName)
-                        syncGroup.leave()
-                    } catch {
-                        imageSaveErrorCount += 1
-                        syncGroup.leave()
-                        promise.reject(error)
-                    }
-                }
-            }
-            syncGroup.notify(queue: DispatchQueue.main) {
-                guard imageSaveErrorCount == 0 else {
-                    promise.reject(SyncJSONDownloader.Error.failedToWriteFiles(imageSaveErrorCount))
-                    return
-                }
-                promise.fulfill(())
-            }
-        }
-    }
-
     private func fetchLocales(withClient client: Client) -> Promise<Void> {
         return Promise { promise in
             _ = client.fetch(url: client.url(endpoint: .locales)) { [weak self] result in
@@ -102,20 +81,55 @@ public final class SyncJSONDownloader {
         }
     }
 
-    private func fetchSync(withClient client: Client, syncSpace: SyncSpace) -> Promise<Void> {
+    private func fetchContent(withClient client: Client, syncSpace: SyncSpace) -> Promise<Void> {
         return Promise { promise in
-            do {
-                let data = try JSONEncoder().encode(syncSpace.entries)
-                try writeJSONDataToDisk(data, withFileName: "entries")
-                promise.fulfill(())
-            } catch {
-                promise.reject(error)
-            }
+            _ = client.fetchContent(
+                for: syncSpace,
+                shouldDownloadAssets: shouldDownloadMediaFiles,
+                reportDownloadedSyncSpace: { [weak self] downloadedSyncSpace, data, url in
+                guard let self = self else {
+                    promise.reject(SyncJSONDownloader.Error.clientNotAvailable)
+                    return
+                }
+
+                do {
+                    let fileName = String(self.entriesFileNameIndex)
+                    self.entriesFileNameIndex += 1
+
+                    try self.writeJSONDataToDisk(data, withFileName: fileName)
+
+                } catch let error {
+                    promise.reject(error)
+                }
+
+            }, reportDownloadedAsset: { [weak self] (asset, data) in
+                guard let self = self else {
+                    promise.reject(SyncJSONDownloader.Error.clientNotAvailable)
+                    return
+                }
+
+                guard let fileName = asset.file?.fileName else {
+                    return
+                }
+
+                do {
+                    try self.saveData(data, for: fileName)
+                } catch let error {
+                    promise.reject(error)
+                }
+
+            }, then: { result in
+                switch result {
+                case .success:
+                    promise.fulfill(())
+                case .failure(let error):
+                    promise.reject(error)
+                }
+            })
         }
     }
 
-    private func saveData(_ data: Data, for fileName: String?) throws {
-        guard let fileName = fileName else { return }
+    private func saveData(_ data: Data, for fileName: String) throws {
         let folder = try Folder(path: outputDirectoryPath)
         let file = try folder.createFile(named: fileName)
         try file.write(data)
@@ -134,5 +148,6 @@ public extension SyncJSONDownloader {
         case failedToCreateFile
         case failedToWriteFiles(Int)
         case failedToFetchSyncSpace
+        case clientNotAvailable
     }
 }

--- a/Sources/ContentfulUtilities/main.swift
+++ b/Sources/ContentfulUtilities/main.swift
@@ -32,7 +32,7 @@ let bundleSyncCommand = command(
             print("Successfully stored JSON files for sync operation in directory \(CommandLine.arguments[3])")
             print("Add this directory to your bundle to ensure these files can be used by contentful-persistence.swift")
             exit(0)
-        case let .error(error):
+        case let .failure(error):
             print("Oh no! An error occurred: \(error)")
             exit(1)
         }

--- a/Tests/ContentfulSyncSerializerTests/ContentfulSyncSerializerTests.swift
+++ b/Tests/ContentfulSyncSerializerTests/ContentfulSyncSerializerTests.swift
@@ -35,16 +35,17 @@ class ContentfulSyncSerializerTests: XCTestCase {
             let expectation = self.expectation(description: "Will download JSON files")
             // syncJSONDowloader the tool and assert that the file was created
             syncJSONDowloader.run { result in
-                guard let success = result.value, success == true else {
-                    XCTAssert(false, "SyncJSONDownloader failed to sync json files with error: \(result.error!)")
+                switch result {
+                case .success:
+                    XCTAssertNotNil(try? testFolder.file(named: "locales.json"))
+                    XCTAssertNotNil(try? testFolder.file(named: "0.json"))
+                    XCTAssertNotNil(try? testFolder.file(named: "1.json"))
                     expectation.fulfill()
-                    return
+                    
+                case .failure(let error):
+                    XCTAssert(false, "SyncJSONDownloader failed to sync json files with error: \(error)")
+                    expectation.fulfill()
                 }
-                XCTAssertNotNil(try? testFolder.file(named: "locales.json"))
-                XCTAssertNotNil(try? testFolder.file(named: "entries.json"))
-//                XCTAssertNotNil(try? testFolder.file(named: "1.json"))
-
-                expectation.fulfill()
             }
             waitForExpectations(timeout: 10.0, handler: nil)
             try testFolder.delete()
@@ -84,19 +85,20 @@ class ContentfulSyncSerializerTests: XCTestCase {
             let expectation = self.expectation(description: "Will download JSON files")
             // syncJSONDowloader the tool and assert that the file was created
             syncJSONDowloader.run { result in
-                guard let success = result.value, success == true else {
+                switch result {
+                case .success:
+                    XCTAssertNotNil(try? testFolder.file(named: "locales.json"))
+                    XCTAssertNotNil(try? testFolder.file(named: "0.json"))
+                    XCTAssertNotNil(try? testFolder.file(named: "doge.jpg"))
+                    XCTAssertNotNil(try? testFolder.file(named: "happycatw.jpg"))
+                    XCTAssertNotNil(try? testFolder.file(named: "jake.png"))
+                    XCTAssertNotNil(try? testFolder.file(named: "Nyan_cat_250px_frame.png"))
+                    expectation.fulfill()
+
+                case .failure:
                     XCTAssert(false, "SyncJSONDownloader failed to sync json files")
                     expectation.fulfill()
-                    return
                 }
-                XCTAssertNotNil(try? testFolder.file(named: "locales.json"))
-                XCTAssertNotNil(try? testFolder.file(named: "entries.json"))
-                XCTAssertNotNil(try? testFolder.file(named: "doge.jpg"))
-                XCTAssertNotNil(try? testFolder.file(named: "happycatw.jpg"))
-                XCTAssertNotNil(try? testFolder.file(named: "jake.png"))
-                XCTAssertNotNil(try? testFolder.file(named: "Nyan_cat_250px_frame.png"))
-
-                expectation.fulfill()
             }
             waitForExpectations(timeout: 10.0, handler: nil)
             try testFolder.delete()


### PR DESCRIPTION
Based on the code before the #15 has been introduced I updated the logic of fetching content by utilizing fixes and code from the `Client+Sync` of the `Contentful` SDK 5.3.0. In Contentful 5.3.0 I introduced fixes to pagination during sync and I copied over that logic to this tool. 

The tool is producing 0.json, 1.json and so on instead of big entries.json. The entries.json has different structure than the 0/1.json and is not compatible with the contentful-persistence 0.15.3 library. Thus, I brought back numeric jsons as they work fine with the contentful-persistence 0.15.3.

Changes:
- Brought back an old files structure of the synced data.
- Updated Contentful dependency to 5.3.0.
- Improved the code.
- Updated tests.

Checked with a demo project and my test space and it works well.

Resolves #16 