### PR TITLE
[Feature] Adding syncLimit parameter to reduce amount of json files downloaded.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/contentful/contentful.swift",
         "state": {
           "branch": null,
-          "revision": "91f2306270a76fadc4c0c8237eff22966b608c08",
-          "version": "5.3.0"
+          "revision": "265a67e67fb3a722f73bd298f0879f3878528ca8",
+          "version": "5.5.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/contentful/contentful.swift",
-            .upToNextMajor(from: "5.3.0")),
+            .upToNextMajor(from: "5.5.0")),
         .package(
             url: "https://github.com/kylef/Commander",
             .upToNextMajor(from: "0.9.1")),

--- a/Sources/ContentfulSyncSerializer/SyncJSONDownloader.swift
+++ b/Sources/ContentfulSyncSerializer/SyncJSONDownloader.swift
@@ -11,19 +11,22 @@ public final class SyncJSONDownloader {
     private let shouldDownloadMediaFiles: Bool
     private let environment: String
     private var entriesFileNameIndex: Int = 0
+    private let syncLimit: Int?
 
     public init(
         spaceId: String,
         accessToken: String,
         outputDirectoryPath: String,
         environment: String = "master",
-        shouldDownloadMediaFiles: Bool
+        shouldDownloadMediaFiles: Bool,
+        syncLimit: Int? = nil
     ) {
         self.spaceId = spaceId
         self.environment = environment
         self.accessToken = accessToken
         self.outputDirectoryPath = outputDirectoryPath
         self.shouldDownloadMediaFiles = shouldDownloadMediaFiles
+        self.syncLimit = syncLimit
     }
 
     public func run(then completion: @escaping (Swift.Result<Bool, Swift.Error>) -> Void) {
@@ -38,10 +41,10 @@ public final class SyncJSONDownloader {
         firstly {
             self.sync(client: client)
         }.then { _ in
-            self.fetchLocales(withClient: client).map({ SyncSpace() })
+            self.fetchLocales(withClient: client).map({ SyncSpace(limit: self.syncLimit) })
         }.then { syncSpace in
-            self.fetchContent(withClient: client, syncSpace: syncSpace).map({ SyncSpace() })
-        }.done { _ in
+            self.fetchContent(withClient: client, syncSpace: syncSpace)
+        }.done {
             completion(.success(true))
         }.catch { error in
             completion(.failure(error))

--- a/Sources/ContentfulUtilities/main.swift
+++ b/Sources/ContentfulUtilities/main.swift
@@ -17,14 +17,16 @@ let bundleSyncCommand = command(
     Option<String>("access-token", default: "", description: "Your content delivery API access token"),
     Option<String>("output", default: "", description: "The path to the directory for your output"),
     Option<String>("environment", default: "master", description: "The identifier for your Contentful environment. If value is not specified, master will be used as default"),
-    Flag("download-asset-data", default: false, description: "If true, downloads the binary media files as well")
-) { (spaceId: String, accessToken: String, output: String, environment: String, shouldDownloadMediaFiles: Bool) in
+    Flag("download-asset-data", default: false, description: "If true, downloads the binary media files as well"),
+    Option<Int>("syncLimit", default: 500, description: "Number of entities per page in a sync operation. Defaulted to 500, max 1000. Reduces amount of json files outputted.")
+) { (spaceId: String, accessToken: String, output: String, environment: String, shouldDownloadMediaFiles: Bool, syncLimit: Int) in
 
     let syncJSONDownloader = SyncJSONDownloader(spaceId: spaceId,
                                                 accessToken: accessToken,
                                                 outputDirectoryPath: output,
                                                 environment: environment,
-                                                shouldDownloadMediaFiles: shouldDownloadMediaFiles)
+                                                shouldDownloadMediaFiles: shouldDownloadMediaFiles,
+                                                syncLimit: syncLimit)
 
     syncJSONDownloader.run { result in
         switch result {


### PR DESCRIPTION
Adding the capability to use the functionality added within https://github.com/contentful/contentful.swift/pull/322/files to the command line tool.

This results in a lot of less json files if you use the maximum allowed limit, which reduces the time taken by [SynchronizationManager.seedDBFromJSONFiles](https://github.com/contentful/contentful-persistence.swift/blob/master/Sources/ContentfulPersistence/SynchronizationManager%2BSeedDB.swift#L24) to process all the JSON files.
